### PR TITLE
history: Move getting room and user history into -core.

### DIFF
--- a/src/controllers/booth.js
+++ b/src/controllers/booth.js
@@ -1,8 +1,4 @@
 import Promise from 'bluebird';
-// Will be unnecessary later when a history module exists in -core.
-// For now we'll assume that we've got a u-wave-core peer installed.
-// eslint-disable-next-line
-import Page from 'u-wave-core/lib/Page';
 
 import { createCommand } from '../sockets';
 import { NotFoundError, PermissionError } from '../errors';
@@ -152,31 +148,6 @@ export async function favorite(uw, id, playlistID, historyID) {
   };
 }
 
-export async function getHistory(uw, pagination, filter = {}) {
-  const History = uw.model('History');
-
-  const history = await History.find({})
-    .where(filter)
-    .skip(pagination.offset)
-    .limit(pagination.limit)
-    .sort({ playedAt: -1 })
-    .populate('media.media user');
-
-  const count = await History.where(filter).count();
-
-  return new Page(history, {
-    pageSize: pagination ? pagination.limit : null,
-    filtered: count,
-    total: count,
-
-    current: pagination,
-    next: pagination ? {
-      offset: pagination.offset + pagination.limit,
-      limit: pagination.limit,
-    } : null,
-    previous: pagination ? {
-      offset: Math.max(pagination.offset - pagination.limit, 0),
-      limit: pagination.limit,
-    } : null,
-  });
+export function getHistory(uw, pagination) {
+  return uw.getHistory(pagination);
 }

--- a/src/controllers/users.js
+++ b/src/controllers/users.js
@@ -30,5 +30,5 @@ export async function disconnectUser(uw, user) {
 
 export async function getHistory(uw, id, pagination) {
   const user = await uw.getUser(id);
-  return user.getPlayHistory(pagination);
+  return user.getHistory(pagination);
 }

--- a/src/controllers/users.js
+++ b/src/controllers/users.js
@@ -2,10 +2,7 @@ import clamp from 'clamp';
 
 import { createCommand } from '../sockets';
 
-import {
-  skipIfCurrentDJ,
-  getHistory as getHistoryBase,
-} from './booth';
+import { skipIfCurrentDJ } from './booth';
 import { leaveWaitlist } from './waitlist';
 
 export function setStatus(uw, id, status) {
@@ -31,6 +28,7 @@ export async function disconnectUser(uw, user) {
   uw.publish('user:leave', { userID });
 }
 
-export function getHistory(uw, id, pagination) {
-  return getHistoryBase(uw, pagination, { user: id });
+export async function getHistory(uw, id, pagination) {
+  const user = await uw.getUser(id);
+  return user.getPlayHistory(pagination);
 }


### PR DESCRIPTION
ref u-wave/core#92

Uses the new `getHistory` methods from -core.